### PR TITLE
Introduce ‘control panel’ namespace

### DIFF
--- a/app/controllers/control_panel/channels/suspensions_controller.rb
+++ b/app/controllers/control_panel/channels/suspensions_controller.rb
@@ -1,0 +1,15 @@
+class ControlPanel::Channels::SuspensionsController < ApplicationController
+  before_action :set_channel
+
+  def create
+    @channel.update(suspended_at: Time.zone.now)
+    flash['notice'] = "#{@channel.name} has been suspended."
+    redirect_to control_panel_channel_path(@channel)
+  end
+
+  private
+
+  def set_channel
+    @channel = Channel.find(params[:channel_id])
+  end
+end

--- a/app/controllers/control_panel/channels_controller.rb
+++ b/app/controllers/control_panel/channels_controller.rb
@@ -1,0 +1,12 @@
+class ControlPanel::ChannelsController < ApplicationController
+  before_action :set_channel
+
+  def show
+  end
+
+  private
+
+  def set_channel
+    @channel = Channel.find(params[:id])
+  end
+end

--- a/app/views/control_panel/channels/show.html.erb
+++ b/app/views/control_panel/channels/show.html.erb
@@ -4,3 +4,10 @@
 <h3>
   <%= @channel.name %>
 </h3>
+<% if @channel.suspended_at.present? %>
+  SUSPENDED
+<% else %>
+  VALID
+<% end %>
+
+<%= button_to 'Suspend', control_panel_channel_suspension_path(@channel), method: :post, class: 'rounded-lg px-4 md:px-5 xl:px-4 py-3 md:py-4 xl:py-3 bg-teal-500 hover:bg-teal-600 md:text-lg xl:text-base text-white font-semibold leading-tight shadow-md' %>

--- a/app/views/control_panel/channels/show.html.erb
+++ b/app/views/control_panel/channels/show.html.erb
@@ -1,0 +1,6 @@
+<h1>
+  Control Panel
+</h1>
+<h3>
+  <%= @channel.name %>
+</h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
   namespace :control_panel, path: 'controlpanel' do
-    resources :channels, only: :show
+    resources :channels, only: :show do
+      resource :suspension, only: :create, module: :channels
+    end
   end
 
   resources :channels, only: [:show, :edit, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  namespace :control_panel, path: 'controlpanel' do
+    resources :channels, only: :show
+  end
+
   resources :channels, only: [:show, :edit, :update]
 end

--- a/db/migrate/20200927105813_add_suspended_at_to_channels.rb
+++ b/db/migrate/20200927105813_add_suspended_at_to_channels.rb
@@ -1,0 +1,5 @@
+class AddSuspendedAtToChannels < ActiveRecord::Migration[6.0]
+  def change
+    add_column :channels, :suspended_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_13_111447) do
+ActiveRecord::Schema.define(version: 2020_09_27_105813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_09_13_111447) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "organisation_id"
+    t.datetime "suspended_at"
   end
 
   create_table "organisations", force: :cascade do |t|

--- a/spec/controllers/control_panel/channels/suspensions_controller_spec.rb
+++ b/spec/controllers/control_panel/channels/suspensions_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ControlPanel::Channels::SuspensionsController, type: :controller do
+  let(:channel) { FactoryBot.create(:channel) }
+
+  context '#create' do
+    it 'should suspend the channel' do
+      post :create, params: { channel_id: channel.id }
+      expect(channel.reload.suspended_at).to_not be_nil
+    end
+  end
+end

--- a/spec/controllers/control_panel/channels_controller_spec.rb
+++ b/spec/controllers/control_panel/channels_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ControlPanel::ChannelsController, type: :controller do
+  let(:channel) { FactoryBot.create(:channel) }
+
+  context '#show' do
+    it 'should return a successful response' do
+      get :show, params: { id: channel.id }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
As part of the stream looking at how we might introduce the concept of 'admin' functionality to the app, we've added the 'control panel' namespace. In later streams, we'll add permissions so that only appropriate users have access to controllers within this namespace.

As part of that work, this PR also introduces the idea of ‘suspending’ a channel - this is only really used as an example of something only an admin would be allowed to do and there's no other planning or anything in the feature, it's just an example for now.

Watch the stream where all this was added here: https://youtu.be/TbRw2jHpgg0