### PR TITLE
Install pundit and set up initial 'dummy' policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 gem "devise", "~> 4.7"
+gem "pundit"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
     public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     rack (2.2.3)
     rack-proxy (0.6.5)
       rack
@@ -254,6 +256,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 4.1)
+  pundit
   rails (~> 6.0.3, >= 6.0.3.2)
   rails-controller-testing
   rspec-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  include Pundit
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = "You are not authorized to perform this action."
+    redirect_to(request.referrer || '/')
+  end
 end

--- a/app/controllers/control_panel/base_controller.rb
+++ b/app/controllers/control_panel/base_controller.rb
@@ -1,0 +1,3 @@
+class ControlPanel::BaseController < ApplicationController
+  before_action :authenticate_user!
+end

--- a/app/controllers/control_panel/base_controller.rb
+++ b/app/controllers/control_panel/base_controller.rb
@@ -1,3 +1,7 @@
 class ControlPanel::BaseController < ApplicationController
   before_action :authenticate_user!
+
+  def authorize(record, query = nil)
+    super([:control_panel, record], query)
+  end
 end

--- a/app/controllers/control_panel/channels/suspensions_controller.rb
+++ b/app/controllers/control_panel/channels/suspensions_controller.rb
@@ -1,4 +1,4 @@
-class ControlPanel::Channels::SuspensionsController < ApplicationController
+class ControlPanel::Channels::SuspensionsController < ControlPanel::BaseController
   before_action :set_channel
 
   def create

--- a/app/controllers/control_panel/channels_controller.rb
+++ b/app/controllers/control_panel/channels_controller.rb
@@ -1,4 +1,4 @@
-class ControlPanel::ChannelsController < ApplicationController
+class ControlPanel::ChannelsController < ControlPanel::BaseController
   before_action :set_channel
 
   def show

--- a/app/controllers/control_panel/channels_controller.rb
+++ b/app/controllers/control_panel/channels_controller.rb
@@ -2,6 +2,7 @@ class ControlPanel::ChannelsController < ControlPanel::BaseController
   before_action :set_channel
 
   def show
+    authorize @channel
   end
 
   private

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,0 +1,4 @@
+class StaticController < ApplicationController
+  def home_page
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,49 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/control_panel/channel_policy.rb
+++ b/app/policies/control_panel/channel_policy.rb
@@ -1,0 +1,5 @@
+class ControlPanel::ChannelPolicy < ApplicationPolicy
+  def show?
+    user.present?
+  end
+end

--- a/app/views/static/home_page.html.erb
+++ b/app/views/static/home_page.html.erb
@@ -1,0 +1,1 @@
+Sundae Club Home Page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,6 @@ Rails.application.routes.draw do
   end
 
   resources :channels, only: [:show, :edit, :update]
+
+  root 'static#home_page'
 end

--- a/spec/controllers/control_panel/channels/suspensions_controller_spec.rb
+++ b/spec/controllers/control_panel/channels/suspensions_controller_spec.rb
@@ -6,9 +6,13 @@ describe ControlPanel::Channels::SuspensionsController, type: :controller do
   let(:channel) { FactoryBot.create(:channel) }
 
   context '#create' do
-    it 'should suspend the channel' do
-      post :create, params: { channel_id: channel.id }
-      expect(channel.reload.suspended_at).to_not be_nil
+    context 'with a confirmed, signed-in user' do
+      before { sign_in FactoryBot.create(:user, :confirmed) }
+
+      it 'should suspend the channel' do
+        post :create, params: { channel_id: channel.id }
+        expect(channel.reload.suspended_at).to_not be_nil
+      end
     end
   end
 end

--- a/spec/controllers/control_panel/channels_controller_spec.rb
+++ b/spec/controllers/control_panel/channels_controller_spec.rb
@@ -6,9 +6,13 @@ describe ControlPanel::ChannelsController, type: :controller do
   let(:channel) { FactoryBot.create(:channel) }
 
   context '#show' do
-    it 'should return a successful response' do
-      get :show, params: { id: channel.id }
-      expect(response).to have_http_status(:ok)
+    context 'with a confirmed, signed-in user' do
+      before { sign_in FactoryBot.create(:user, :confirmed) }
+
+      it 'should return a successful response' do
+        get :show, params: { id: channel.id }
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 end

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe StaticController, type: :controller do
+  context '#home_page' do
+    it 'should return a successful response' do
+      get :home_page
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user do
-    
+    sequence(:email) { |n| "user.num#{n}@example.com" }
+    password 'password'
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user.num#{n}@example.com" }
     password 'password'
+
+    trait :confirmed do
+      confirmed_at Time.current
+    end
   end
 end

--- a/spec/features/static/home_page_spec.rb
+++ b/spec/features/static/home_page_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'As a non-logged-in visitor' do
+  context 'when I visit the home page' do
+    scenario 'I should see the home page' do
+      visit root_path
+      expect(page).to have_content('Sundae Club Home Page')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,6 +28,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::ControllerHelpers, type: :controller
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
In this PR, we're installing the Pundit gem having [looked at other options for authorisation gems](https://youtu.be/77Z_u2QDTZA). We create a 'base' controller from which all controllers in our `ControlPanel` namespace can inherit, and set up our initial policy.

Not enough tests added in here as these were added in some later livestreams where we changed some of the initial assumptions about the modelling in the app, so I'm happy to merge this knowing those tests will be added later.

You can see the livestream where we looked at adding user authorisation to our Rails app:
https://www.youtube.com/watch?v=77Z_u2QDTZA