### PR TITLE
Add 'Sites', including creation from the home page.

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class SitesController < ApplicationController
+  def create
+    @site = Site.new(site_params)
+    @organisation = @site.build_organisation(name: 'TestOrg')
+    if @site.save
+      flash[:notice] = "#{@site.name} has been created."
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
+  end
+
+  private
+
+  def site_params
+    params.require(:site).permit(:name)
+  end
+end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class StaticController < ApplicationController
   def home_page
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,0 +1,3 @@
+class Site < ApplicationRecord
+  belongs_to :organisation
+end

--- a/app/views/static/home_page.html.erb
+++ b/app/views/static/home_page.html.erb
@@ -1,1 +1,5 @@
 Sundae Club Home Page
+<%= form_with model: Site.new do |f| %>
+  <%= f.text_field :name, class: 'border rounded-md' %>
+  <%= f.submit 'Create Site', class: 'rounded-lg px-4 md:px-5 xl:px-4 py-3 md:py-4 xl:py-3 bg-teal-500 hover:bg-teal-600 md:text-lg xl:text-base text-white font-semibold leading-tight shadow-md' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :sites, only: [:create]
   resources :channels, only: [:show, :edit, :update]
 
   root 'static#home_page'

--- a/db/migrate/20201025115207_create_sites.rb
+++ b/db/migrate/20201025115207_create_sites.rb
@@ -1,0 +1,11 @@
+class CreateSites < ActiveRecord::Migration[6.0]
+  def change
+    create_table :sites do |t|
+      t.text :name
+      t.text :description
+      t.text :slug
+      t.references :organisation, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_11_101347) do
+ActiveRecord::Schema.define(version: 2020_10_25_115207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,16 @@ ActiveRecord::Schema.define(version: 2020_10_11_101347) do
     t.text "slug"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "sites", force: :cascade do |t|
+    t.text "name"
+    t.text "description"
+    t.text "slug"
+    t.bigint "organisation_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["organisation_id"], name: "index_sites_on_organisation_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -54,4 +64,5 @@ ActiveRecord::Schema.define(version: 2020_10_11_101347) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "sites", "organisations"
 end

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SitesController, type: :controller do
+  context '#create' do
+    context 'as a non-logged-in visitor' do
+      let(:create_action) do
+        post :create, params: { site: { name: 'TestName' } }
+      end
+
+      it 'should create a valid site' do
+        expect { create_action }.to change { Site.count }.by(1)
+      end
+    end
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Site, type: :model do
+  it { is_expected.to belong_to(:organisation) }
+end


### PR DESCRIPTION
We initially planned on a user creating a Channel and using that as the primary resource we would use to create a site. As we thought about it, we realised we may want to add multiple other channels and have other content on the 'site' we create via the app, so added a new model to represent it.

Here's a link to the livestream where we looked at planning these changes: https://youtu.be/YDS_DKsCXyo