### PR TITLE
Add association between User and Organisation models

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,3 +1,4 @@
 class Organisation < ApplicationRecord
   has_many :channels
+  has_many :users
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :confirmable, :trackable
+  belongs_to :organisation
+
+  validates :organisation, presence: true
 end

--- a/db/migrate/20201108110206_add_organisation_id_to_users.rb
+++ b/db/migrate/20201108110206_add_organisation_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddOrganisationIdToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :users, :organisation, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_25_115207) do
+ActiveRecord::Schema.define(version: 2020_11_08_110206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,10 +59,13 @@ ActiveRecord::Schema.define(version: 2020_10_25_115207) do
     t.string "unconfirmed_email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "organisation_id", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "sites", "organisations"
+  add_foreign_key "users", "organisations"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user.num#{n}@example.com" }
     password 'password'
+    organisation
 
     trait :confirmed do
       confirmed_at Time.current

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Organisation, type: :model do
   it { is_expected.to have_many(:channels) }
+  it { is_expected.to have_many(:users) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { is_expected.to belong_to(:organisation) }
+  it { is_expected.to validate_presence_of(:organisation) }
 end


### PR DESCRIPTION
In the early streams, I added `Organisation` as a way of adding some additional complexity between a user and their channels to make the streams more useful. I think the original, vague plan was to make a has-and-belongs-to-many (HABTM) relationship between `User` and `Organisation`.

This got more complex when weeks later we added in the `Site` model, and suddenly didn't need to add any artificial complexity 😆 In [this stream](https://youtu.be/SqrjDCyY9Nw?t=1208), you can see me walk that plan back a little and start work on this PR where we add an association so that an organisation has many users.

You can see this being worked on as part of the livestream where we tidied up the user-onboarding steps we built over several streams here: https://youtu.be/SqrjDCyY9Nw?t=1208