### PR TITLE
Use user's organisation for CP channels controller auth

### DIFF
--- a/app/policies/control_panel/channel_policy.rb
+++ b/app/policies/control_panel/channel_policy.rb
@@ -1,5 +1,5 @@
 class ControlPanel::ChannelPolicy < ApplicationPolicy
   def show?
-    user.present?
+    user.organisation == record.organisation
   end
 end

--- a/spec/controllers/control_panel/channels_controller_spec.rb
+++ b/spec/controllers/control_panel/channels_controller_spec.rb
@@ -6,8 +6,11 @@ describe ControlPanel::ChannelsController, type: :controller do
   let(:channel) { FactoryBot.create(:channel) }
 
   context '#show' do
-    context 'with a confirmed, signed-in user' do
-      before { sign_in FactoryBot.create(:user, :confirmed) }
+    context 'with a confirmed, signed-in user that belongs to the same organisation as the channel' do
+      let(:user) { FactoryBot.create(:user, :confirmed) }
+      let(:channel) { FactoryBot.create(:channel, organisation: user.organisation) }
+
+      before { sign_in user }
 
       it 'should return a successful response' do
         get :show, params: { id: channel.id }


### PR DESCRIPTION
When it was originally written on the livestream, the authorisation check for the control panel channels controller was "is there a logged in user". This matched devise's `authenticate_user!` method which we'd implemented on a previous stream.

In recent work we added an association between User and Organistion.

In this commit we're able to replace our initial and less-than-ideal "any user" authorisation and ensure that only user that belongs to the same organisation as the channel can access the control panel channels controller.