### PR TITLE
Replace channel/org association with channel/site association

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,3 +1,5 @@
 class Channel < ApplicationRecord
-  belongs_to :organisation
+  belongs_to :site
+
+  validates :site, presence: true
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,4 @@
 class Organisation < ApplicationRecord
-  has_many :channels
   has_many :users
+  has_many :sites
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,3 +1,4 @@
 class Site < ApplicationRecord
   belongs_to :organisation
+  has_many :channels
 end

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -4,7 +4,7 @@
   </h1>
 
   <h4>
-    Organisation: <%= @channel.organisation.name %>
+    Organisation: <%= @channel.site.organisation.name %>
   </h4>
   <%= link_to 'Edit Channel', edit_channel_path(@channel), class: 'text-blue-500' %>
 </div>

--- a/db/migrate/20201108112603_add_site_id_to_channels_remove_organisation.rb
+++ b/db/migrate/20201108112603_add_site_id_to_channels_remove_organisation.rb
@@ -1,0 +1,6 @@
+class AddSiteIdToChannelsRemoveOrganisation < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :channels, :site, null: false, foreign_key: true
+    remove_column :channels, :organisation_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_08_110206) do
+ActiveRecord::Schema.define(version: 2020_11_08_112603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,8 +21,9 @@ ActiveRecord::Schema.define(version: 2020_11_08_110206) do
     t.text "slug"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "organisation_id"
     t.datetime "suspended_at"
+    t.bigint "site_id", null: false
+    t.index ["site_id"], name: "index_channels_on_site_id"
   end
 
   create_table "organisations", force: :cascade do |t|
@@ -66,6 +67,7 @@ ActiveRecord::Schema.define(version: 2020_11_08_110206) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "channels", "sites"
   add_foreign_key "sites", "organisations"
   add_foreign_key "users", "organisations"
 end

--- a/spec/factories/channels.rb
+++ b/spec/factories/channels.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     name "MyText"
     description "MyText"
     slug "MyText"
-    organisation
+    site
   end
 end

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Channel, type: :model do
-  it { is_expected.to belong_to(:organisation) }
+  it { is_expected.to belong_to(:site) }
+  it { is_expected.to validate_presence_of(:site) }
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Organisation, type: :model do
-  it { is_expected.to have_many(:channels) }
   it { is_expected.to have_many(:users) }
+  it { is_expected.to have_many(:sites) }
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Site, type: :model do
   it { is_expected.to belong_to(:organisation) }
+  it { is_expected.to have_many(:channels) }
 end


### PR DESCRIPTION
In the initial livestreams, we initially thought an organisation would have many channels. Later we introduced the idea of the Site model which would sit between the two so that we can handle sites that had multiple channels.

This PR removes our initial channel/org association and replaces it with a channel/site association.